### PR TITLE
Update README to include the new link for Hashicorp AWS Tutorials. The previous link is has moved (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > We are committed to providing learning resources that are accessible to all. If you see a resource that is not compliant, please let us know by [creating an issue](https://github.com/cds-snc/terraform-demo/issues).
 
 - [Slides](https://docs.google.com/presentation/d/1fAJBXQuxhNtrjaaIYOSN2YDJl92bhPgyf4VKySnzDIk/edit#slide=id.gfa3975480b_0_3)
-- [HashiCorp Learn](https://learn.hashicorp.com/tutorials/terraform/)
+- [HashiCorp Tutorials](https://developer.hashicorp.com/terraform/tutorials/aws-get-started)
 - [A Cloud Guru](https://learn.acloud.guru/)
 - [New Relic](https://www.hashicorp.com/partners/tech/new-relic)
 - [CDS Terraform Modules](https://github.com/cds-snc/terraform-modules)


### PR DESCRIPTION
# Summary | Résumé

Update README to include the new link for Hashicorp AWS Tutorials. The previous link has moved (404)